### PR TITLE
Update immutable_cache for PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -35,6 +35,10 @@ jobs:
            PHP_VERSION_FULL: 8.2.10
          - PHP_VERSION: '8.2'
            PHP_VERSION_FULL: 8.2.10
+         - PHP_VERSION: '8.3'
+           PHP_VERSION_FULL: 8.3.0
+         - PHP_VERSION: '8.4'
+           PHP_VERSION_FULL: 8.4.0
            DOCKER_ARCHITECTURE: i386
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,9 @@
 PHP_ARG_ENABLE(immutable_cache, whether to enable immutable_cache support,
-[  --enable-immutable-cache           Enable immutable_cache support])
+[  --enable-immutable_cache         Enable immutable_cache support])
 
+PHP_ADD_EXTENSION_DEP(immutable_cache, random)
+
+PHP_ADD_INCLUDE(/opt/homebrew/opt/pcre2/include)
 AC_MSG_CHECKING(if immutable_cache should be allowed to use rwlocks)
 AC_ARG_ENABLE(immutable-cache-rwlocks,
 [  --disable-immutable-cache-rwlocks  Disable rwlocks in immutable_cache],
@@ -62,7 +65,6 @@ AC_MSG_RESULT($PHP_IMMUTABLE_CACHE_SPINLOCK)
 
 if test "$PHP_IMMUTABLE_CACHE_RWLOCKS" != "no"; then
   AC_CACHE_CHECK([whether the target compiler supports builtin atomics], PHP_cv_IMMUTABLE_CACHE_GCC_ATOMICS, [
-
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
         int foo = 0;
         __sync_add_and_fetch(&foo, 1);
@@ -95,8 +97,8 @@ if test "$PHP_IMMUTABLE_CACHE" != "no"; then
     AC_MSG_ERROR([failed to detect PHP version, please report])
   fi
 
-  if test "$php_version" -lt "70200"; then
-    AC_MSG_ERROR([You need at least PHP 7.2.0 to be able to use this version of immutable_cache. PHP $php_version found])
+  if test "$php_version" -lt "80400"; then
+    AC_MSG_ERROR([You need at least PHP 8.4.0 to be able to use this version of immutable_cache. PHP $php_version found])
   else
     AC_MSG_RESULT([$php_version, ok])
   fi
@@ -267,11 +269,12 @@ if test "$PHP_IMMUTABLE_CACHE" != "no"; then
                  immutable_cache_persist.c"
 
   PHP_CHECK_LIBRARY(rt, shm_open, [PHP_ADD_LIBRARY(rt,,IMMUTABLE_CACHE_SHARED_LIBADD)])
-  PHP_NEW_EXTENSION(immutable_cache, $immutable_cache_sources, $ext_shared,, \\$(IMMUTABLE_CACHE_CFLAGS))
+  PHP_ADD_INCLUDE(/opt/homebrew/Cellar/php/8.4.3/include/php/ext/standard)
+  PHP_NEW_EXTENSION(immutable_cache, $immutable_cache_sources, $ext_shared,, -DZEND_COMPILE_DL_EXT=1$(IMMUTABLE_CACHE_CFLAGS))
   PHP_SUBST(IMMUTABLE_CACHE_SHARED_LIBADD)
   PHP_SUBST(IMMUTABLE_CACHE_CFLAGS)
   PHP_SUBST(PHP_LDFLAGS)
-  PHP_INSTALL_HEADERS(ext/immutable_cache, [php_immutable_cache.h immutable_cache.h immutable_cache_api.h immutable_cache_cache.h immutable_cache_globals.h immutable_cache_iterator.h immutable_cache_lock.h immutable_cache_mutex.h immutable_cache_sma.h immutable_cache_serializer.h immutable_cache_stack.h immutable_cache_arginfo.h php_immutable_cache_legacy_arginfo.h])
+  PHP_INSTALL_HEADERS(ext/immutable_cache, [php_immutable_cache.h immutable_cache.h immutable_cache_api.h immutable_cache_cache.h immutable_cache_globals.h immutable_cache_iterator.h immutable_cache_lock.h immutable_cache_mutex.h immutable_cache_sma.h immutable_cache_serializer.h immutable_cache_stack.h immutable_cache_arginfo.h php_immutable_cache_legacy_arginfo.h php_immutable_cache_php84_arginfo.h])
   AC_DEFINE(HAVE_IMMUTABLE_CACHE, 1, [ ])
 fi
 

--- a/config.m4
+++ b/config.m4
@@ -269,7 +269,7 @@ if test "$PHP_IMMUTABLE_CACHE" != "no"; then
                  immutable_cache_persist.c"
 
   PHP_CHECK_LIBRARY(rt, shm_open, [PHP_ADD_LIBRARY(rt,,IMMUTABLE_CACHE_SHARED_LIBADD)])
-  PHP_ADD_INCLUDE(/opt/homebrew/Cellar/php/8.4.3/include/php/ext/standard)
+  PHP_ADD_INCLUDE(`$PHP_CONFIG --include-dir`/ext/standard)
   PHP_NEW_EXTENSION(immutable_cache, $immutable_cache_sources, $ext_shared,, -DZEND_COMPILE_DL_EXT=1$(IMMUTABLE_CACHE_CFLAGS))
   PHP_SUBST(IMMUTABLE_CACHE_SHARED_LIBADD)
   PHP_SUBST(IMMUTABLE_CACHE_CFLAGS)

--- a/immutable_cache_shm.c
+++ b/immutable_cache_shm.c
@@ -46,7 +46,12 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>
-#include <ext/standard/php_rand.h>
+#if PHP_VERSION_ID >= 80200
+# include "ext/random/php_random.h"
+#else
+# include "ext/standard/php_rand.h"
+#endif
+#include "php.h"
 #endif
 
 #ifndef SHM_R

--- a/php_immutable_cache.c
+++ b/php_immutable_cache.c
@@ -54,8 +54,10 @@
 #include "ext/standard/flock_compat.h"
 #include "ext/standard/md5.h"
 #include "ext/standard/php_var.h"
-#if PHP_VERSION_ID >= 80000
-# include "php_immutable_cache_arginfo.h"
+#if PHP_VERSION_ID >= 80000 && PHP_VERSION_ID < 84000
+# include "php_immutable_cache_php84_arginfo.h"
+#elif PHP_VERSION_ID >= 84000
+# include "php_immutable_cache_php84_arginfo.h"
 #else
 # include "php_immutable_cache_legacy_arginfo.h"
 #endif
@@ -116,7 +118,9 @@ static PHP_INI_MH(OnUpdateShmSegments) /* {{{ */
 
 static PHP_INI_MH(OnUpdateShmSize) /* {{{ */
 {
-#if PHP_VERSION_ID >= 80200
+#if PHP_VERSION_ID >= 84000
+	zend_long s = zend_ini_parse_quantity_warn(new_value, entry->name);
+#elif PHP_VERSION_ID >= 80200
 	zend_long s = zend_ini_parse_quantity_warn(new_value, entry->name);
 #else
 	zend_long s = zend_atol(new_value->val, new_value->len);
@@ -633,6 +637,17 @@ static const zend_module_dep immutable_cache_deps[] = {
 };
 
 /* {{{ module definition structure */
+
+ZEND_DLEXPORT const zend_function_entry ext_functions[] = {
+	ZEND_FE(immutable_cache_enabled, arginfo_immutable_cache_enabled)
+	ZEND_FE(immutable_cache_add, arginfo_immutable_cache_add)
+	ZEND_FE(immutable_cache_fetch, arginfo_immutable_cache_fetch)
+	ZEND_FE(immutable_cache_exists, arginfo_immutable_cache_exists)
+	ZEND_FE(immutable_cache_cache_info, arginfo_immutable_cache_cache_info)
+	ZEND_FE(immutable_cache_key_info, arginfo_immutable_cache_key_info)
+	ZEND_FE(immutable_cache_sma_info, arginfo_immutable_cache_sma_info)
+	ZEND_FE_END
+};
 
 zend_module_entry immutable_cache_module_entry = {
 	STANDARD_MODULE_HEADER_EX,

--- a/php_immutable_cache_php84_arginfo.h
+++ b/php_immutable_cache_php84_arginfo.h
@@ -1,0 +1,47 @@
+#ifndef PHP_IMMUTABLE_CACHE_PHP84_ARGINFO_H
+#define PHP_IMMUTABLE_CACHE_PHP84_ARGINFO_H
+#endif /* PHP_IMMUTABLE_CACHE_PHP84_ARGINFO_H */
+
+#include "php.h"
+#include "Zend/zend.h"
+
+#if PHP_VERSION_ID >= 84000
+#endif /* PHP_VERSION_ID >= 84000 */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_immutable_cache_enabled, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_immutable_cache_add, 0, 1, MAY_BE_ARRAY|MAY_BE_BOOL)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_immutable_cache_fetch, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, success, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_immutable_cache_exists, 0, 1, MAY_BE_ARRAY|MAY_BE_BOOL)
+	ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_immutable_cache_cache_info, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limited, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_immutable_cache_key_info, 0, 1, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_immutable_cache_sma_info arginfo_immutable_cache_cache_info
+
+
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_enabled);
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_add);
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_fetch);
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_exists);
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_cache_info);
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_key_info);
+PHP_IMMUTABLE_CACHE_API ZEND_FUNCTION(immutable_cache_sma_info);
+
+
+extern const zend_function_entry ext_functions[];


### PR DESCRIPTION
Added PHP 8.4 specific arginfo headers, adjusted memory handling, and included necessary dependency updates to ensure compatibility. Minor code refinements and header adjustments were made for improved configuration and cross-version functionality.

## Summary by Sourcery

PHP拡張機能をPHP 8.4との互換性を確保するために更新しました。

新機能:
- PHP 8.4との互換性を導入。

機能強化:
- PHP 8.4固有のarginfo ヘッダーを追加。
- メモリ管理を調整。
- 依存関係を更新。
- コードを洗練し、設定と複数バージョン間の機能性を向上するためにヘッダーを調整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the PHP extension to ensure compatibility with PHP 8.4.

New Features:
- Introduce PHP 8.4 compatibility.

Enhancements:
- Add PHP 8.4 specific arginfo headers.
- Adjust memory handling.
- Update dependencies.
- Refine code and adjust headers for improved configuration and cross-version functionality.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced caching capabilities with new public API functions for enabling caching, adding and fetching cache entries, and retrieving cache details.
	- Improved compatibility with PHP by raising the minimum required version to 8.4 and adding necessary dependency support.
	- Added support for PHP versions 8.3 and 8.4 in the build configuration.

- **Chores**
	- Refined configuration settings with updated compilation flags and header management.
	- Adjusted conditional logic to ensure optimal random number generation across supported PHP versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->