### PR TITLE
Add PHP 8.4 and 8.5 support

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -71,8 +71,8 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - PHP_VERSION: '8.5'
-           PHP_VERSION_FULL: 8.5.0
+         - PHP_VERSION: '8.5-rc'
+           PHP_VERSION_FULL: 8.5.0RC4
     steps:
       - uses: actions/checkout@v4
       - name: Build and test in docker
@@ -84,16 +84,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
           arch: [x64]
           ts: [nts, ts]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout immutable_cache
         uses: actions/checkout@v4
       - name: Setup PHP
         id: setup-php
-        uses: cmb69/setup-php-sdk@v0.7
+        uses: php/setup-php-sdk@v0.10
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -36,6 +36,13 @@ jobs:
          - PHP_VERSION: '8.2'
            PHP_VERSION_FULL: 8.2.10
            DOCKER_ARCHITECTURE: i386
+         - PHP_VERSION: '8.3'
+           PHP_VERSION_FULL: 8.3.14
+         - PHP_VERSION: '8.3'
+           PHP_VERSION_FULL: 8.3.14
+           DOCKER_ARCHITECTURE: i386
+         - PHP_VERSION: '8.4'
+           PHP_VERSION_FULL: 8.4.3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -47,7 +54,7 @@ jobs:
         run: bash ci/test_dockerized.sh ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}
 
       # We reuse the php base image because
-      # 1. It has any necessary dependencies installed for php 7.0-8.2
+      # 1. It has any necessary dependencies installed for php 7.0-8.4
       # 2. It is already downloaded
       #
       # We need to install valgrind then rebuild php from source with the configure option '--with-valgrind' to avoid valgrind false positives
@@ -56,6 +63,20 @@ jobs:
         run: bash ci/test_dockerized_valgrind.sh ${{ matrix.PHP_VERSION }} ${{ matrix.PHP_VERSION_FULL }} ${{ matrix.DOCKER_ARCHITECTURE }}
       # NOTE: tests report false positives for zend_string_equals in php 7.3+
       # due to the use of inline assembly in php-src. (not related to igbinary)
+  ubuntu-php85:
+    # Test PHP 8.5 (development version) - failures are allowed
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+         - PHP_VERSION: '8.5'
+           PHP_VERSION_FULL: 8.5.0
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test in docker
+        run: bash ci/test_dockerized.sh ${{ matrix.PHP_VERSION }} ${{ matrix.DOCKER_ARCHITECTURE }}
   windows:
     defaults:
       run:
@@ -63,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+          version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
           arch: [x64]
           ts: [nts, ts]
     runs-on: windows-latest

--- a/tests/apc54_014.phpt
+++ b/tests/apc54_014.phpt
@@ -3,7 +3,7 @@ APC: Bug #61742 preload_path does not work due to incorrect string length (varia
 --SKIPIF--
 <?php
 require_once(__DIR__ . '/server_skipif.inc');
-if (PHP_ZTS === 1) {
+if (PHP_ZTS) {
     die('skip PHP non-ZTS only');
 }
 ?>

--- a/tests/apc_006_php85.phpt
+++ b/tests/apc_006_php85.phpt
@@ -1,16 +1,14 @@
 --TEST--
-APC: immutable_cache_add/fetch reference test
+APC: immutable_cache_add/fetch reference test (PHP 8.5+)
 --SKIPIF--
 <?php
 require_once(dirname(__FILE__) . '/skipif.inc');
-if (PHP_VERSION_ID < 80100) die('skip Only for PHP >= 8.1');
-if (PHP_VERSION_ID >= 80500) die('skip Only for PHP < 8.5');
+if (PHP_VERSION_ID < 80500) die('skip Only for PHP >= 8.5');
 ?>
 --INI--
 immutable_cache.enabled=1
 immutable_cache.enable_cli=1
 immutable_cache.serializer=php
-report_memleaks=0
 --FILE--
 <?php
 

--- a/tests/ghbug176.phpt
+++ b/tests/ghbug176.phpt
@@ -3,7 +3,7 @@ APC: GH Bug #176 preload_path segfaults with bad data
 --SKIPIF--
 <?php
 require_once(dirname(__FILE__) . '/server_skipif.inc');
-if (PHP_ZTS === 1) {
+if (PHP_ZTS) {
     die('skip PHP non-ZTS only');
 }
 ?>


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for PHP 8.4 and 8.5 to the immutable_cache PECL extension.

## Changes

### PHP 8.4 Compatibility
- Fixed `PHP_ZTS` constant checks in tests (changed from int to bool comparison)
- Updated `tests/apc54_014.phpt` and `tests/ghbug176.phpt`
- All 54 tests pass on PHP 8.4.14

### PHP 8.5 Compatibility  
- Fixed deprecated `report_memleaks` directive in test configuration
- Created new test file `tests/apc_006_php85.phpt` for PHP 8.5+
- Updated `tests/apc_006_php81.phpt` to skip on PHP >= 8.5
- All 55 tests pass on PHP 8.5.0-dev

### CI/CD Updates

**Ubuntu:**
- Added PHP 8.3 (x64/i386) and 8.4 (x64)
- Added PHP 8.5-rc in separate job with `continue-on-error`
- Uses `php:8.5-rc` Docker image for PHP 8.5 RC testing

**Windows:**
- Updated `setup-php-sdk` from v0.7 to v0.10
- Changed repository from `cmb69/setup-php-sdk` to `php/setup-php-sdk`
- Updated runner from `windows-latest` to `windows-2022` (required for PHP 8.4)
- Test matrix now covers PHP 8.0-8.4 (NTS/TS builds)
- Removed PHP 7.2-7.4 from Windows tests (incompatible with windows-2022)

Note: Ubuntu tests still cover PHP 7.2-8.4 for full backward compatibility.

## Test Results

✅ **PHP 8.4.14 (ZTS)**: 54 tests (48 passed, 6 skipped)
✅ **PHP 8.5.0-dev (NTS)**: 55 tests (50 passed, 5 skipped)

## Breaking Changes

None. This PR only adds compatibility with newer PHP versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourceryによる要約

immutable_cache拡張機能にPHP 8.4および8.5の互換性を追加するために、テストとCIパイプラインを更新します。

新機能:
- PHP 8.5+におけるimmutable_cache専用のテストファイルを追加

バグ修正:
- テスト内の`PHP_ZTS`チェックを、整数比較ではなくブール比較を使用するように修正

改善点:
- 既存のPHP 8.1テストをPHP ≥8.5ではスキップするように調整

CI:
- Ubuntu CIマトリックスをPHP 8.3および8.4を含むように拡張し、失敗を許容するPHP 8.5-rcジョブを追加
- Windows CIを`windows-2022`で実行するように更新し、`php/setup-php-sdk@v0.10`を使用し、PHP 8.0–8.4ビルドのみをテスト

テスト:
- テストスイートのスキップ条件を更新し、PHP 8.5+の互換性を追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add PHP 8.4 and 8.5 compatibility to the immutable_cache extension by updating tests and CI pipelines.

New Features:
- Add dedicated test file for immutable_cache on PHP 8.5+

Bug Fixes:
- Fix PHP_ZTS checks in tests to use boolean comparison instead of integer

Enhancements:
- Adjust existing PHP 8.1 test to skip on PHP ≥8.5

CI:
- Expand Ubuntu CI matrix to include PHP 8.3 and 8.4, and add a PHP 8.5-rc job that allows failures
- Update Windows CI to run on windows-2022, use php/setup-php-sdk@v0.10, and test PHP 8.0–8.4 builds only

Tests:
- Update skip conditions and add PHP 8.5+ compatibility in test suite

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added support for testing PHP 8.5 (development version)

* **Tests**
  - Extended PHP version matrix to include PHP 8.3 and 8.4
  - Added new test for PHP 8.5+ compatibility
  - Updated test conditions for PHP version compatibility

* **Chores**
  - Updated testing infrastructure and dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->