### PR TITLE
Support PHP 8.5 build

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -267,7 +267,7 @@ if test "$PHP_IMMUTABLE_CACHE" != "no"; then
                  immutable_cache_persist.c"
 
   PHP_CHECK_LIBRARY(rt, shm_open, [PHP_ADD_LIBRARY(rt,,IMMUTABLE_CACHE_SHARED_LIBADD)])
-  PHP_NEW_EXTENSION(immutable_cache, $immutable_cache_sources, $ext_shared,, \\$(IMMUTABLE_CACHE_CFLAGS))
+  PHP_NEW_EXTENSION(immutable_cache, $immutable_cache_sources, $ext_shared,, $(IMMUTABLE_CACHE_CFLAGS))
   PHP_SUBST(IMMUTABLE_CACHE_SHARED_LIBADD)
   PHP_SUBST(IMMUTABLE_CACHE_CFLAGS)
   PHP_SUBST(PHP_LDFLAGS)

--- a/immutable_cache_shm.c
+++ b/immutable_cache_shm.c
@@ -46,7 +46,12 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>
+#if PHP_VERSION_ID >= 80500
+#include <ext/random/php_random.h>
+#define php_rand() php_mt_rand()
+#else
 #include <ext/standard/php_rand.h>
+#endif
 #endif
 
 #ifndef SHM_R

--- a/tests/apc_006_php81.phpt
+++ b/tests/apc_006_php81.phpt
@@ -9,7 +9,6 @@ if (PHP_VERSION_ID < 80100) die('skip Only for PHP >= 8.1');
 immutable_cache.enabled=1
 immutable_cache.enable_cli=1
 immutable_cache.serializer=php
-report_memleaks=0
 --FILE--
 <?php
 


### PR DESCRIPTION
Builds and passes the test suite on PHP 8.5 (tested with 8.5.6 on macOS/arm64), while keeping 7.4–8.4 working. Three small changes.

## 1. `config.m4` — Makefile flag escaping

`PHP_NEW_EXTENSION(..., \\$(IMMUTABLE_CACHE_CFLAGS))` leaks a literal backslash into the generated Makefile recipe under the current build system:

```
$(EXTRA_CFLAGS)  \ -DZEND_COMPILE_DL_EXT=1 -c ...
clang: error: no such file or directory: " -DZEND_COMPILE_DL_EXT=1"
```

Dropping the leading backslash fixes the recipe. `IMMUTABLE_CACHE_CFLAGS` is still expanded correctly (a plain Makefile variable, `PHP_SUBST`ed below).

## 2. `immutable_cache_shm.c` — `php_rand.h` removed in 8.5

`ext/standard/php_rand.h` no longer exists in PHP 8.5. Use `ext/random/php_random.h` and alias `php_rand()` to `php_mt_rand()` for the SysV IPC key generation, version-guarded so 7.4–8.4 keep the old header:

```c
#if PHP_VERSION_ID >= 80500
#include <ext/random/php_random.h>
#define php_rand() php_mt_rand()
#else
#include <ext/standard/php_rand.h>
#endif
```

## 3. `tests/apc_006_php81.phpt` — drop deprecated `report_memleaks` INI

PHP 8.5 deprecates `report_memleaks` and emits a startup Deprecation notice that leaks into the test output, failing the diff even though the reference/refcount assertions match. The directive only suppressed leak reporting on debug builds and is not needed.

## Verification (PHP 8.5.6)

- `phpize && ./configure && make` complete cleanly
- Extension loads, `immutable_cache_enabled()` true, all functions present
- `run-tests.php`: **50 passed / 0 failed / 4 skipped** (the 4 skips are version-gated `< 8.1` tests)